### PR TITLE
Abstract signaling server client

### DIFF
--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -484,21 +484,23 @@ export class SignalingConn {
   }
 
   setupClient() {
-    this.client = new ws.WebsocketClient(this.url)
-    this.client.on('connect', () => {
-      log(`connected (${this.url})`)
-      const topics = Array.from(rooms.keys())
-      this.client.send({ type: 'subscribe', topics })
-      this.handleConnect()
-    })
-    this.client.on('message', m => {
-      switch (m.type) {
-        case 'publish': {
-          this.handleMessage(m.topic, m.data)
+    if (this.client === undefined) {
+      this.client = new ws.WebsocketClient(this.url)
+      this.client.on('connect', () => {
+        log(`connected (${this.url})`)
+        const topics = Array.from(rooms.keys())
+        this.client.send({ type: 'subscribe', topics })
+        this.handleConnect()
+      })
+      this.client.on('message', m => {
+        switch (m.type) {
+          case 'publish': {
+            this.handleMessage(m.topic, m.data)
+          }
         }
-      }
-    })
-    this.client.on('disconnect', () => log(`disconnect (${this.url})`))
+      })
+      this.client.on('disconnect', () => log(`disconnect (${this.url})`))
+    }
   }
 
   handleConnect() {
@@ -569,7 +571,7 @@ export class SignalingConn {
       execMessage(data)
     }
   }
-  
+
   connected () {
     return this.client.connected
   }

--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -269,8 +269,8 @@ const broadcastRoomMessage = (room, m) => {
 const announceSignalingInfo = room => {
   signalingConns.forEach(conn => {
     // only subscribe if connection is established, otherwise the conn automatically subscribes to all rooms
-    if (conn.connected) {
-      conn.send({ type: 'subscribe', topics: [room.name] })
+    if (conn.connected()) {
+      conn.subscribe(room.name)
       if (room.webrtcConns.size < room.provider.maxConns) {
         publishSignalingMessage(conn, room, { type: 'announce', from: room.peerId })
       }
@@ -412,8 +412,8 @@ export class Room {
   disconnect () {
     // signal through all available signaling connections
     signalingConns.forEach(conn => {
-      if (conn.connected) {
-        conn.send({ type: 'unsubscribe', topics: [this.name] })
+      if (conn.connected()) {
+        conn.unsubscribe(this.name)
       }
     })
     awarenessProtocol.removeAwarenessStates(this.awareness, [this.doc.clientID], 'disconnect')
@@ -466,96 +466,133 @@ const openRoom = (doc, provider, name, key) => {
 const publishSignalingMessage = (conn, room, data) => {
   if (room.key) {
     cryptoutils.encryptJson(data, room.key).then(data => {
-      conn.send({ type: 'publish', topic: room.name, data: buffer.toBase64(data) })
+      conn.publish(room.name, buffer.toBase64(data))
     })
   } else {
-    conn.send({ type: 'publish', topic: room.name, data })
+    conn.publish(room.name, data)
   }
 }
 
-export class SignalingConn extends ws.WebsocketClient {
+/**
+ * @param {SignalingConn} conn
+ * @param {Room} room
+ * @param {any} data
+ */
+const handleMessage = (conn, roomName, data) => {
+  const room = rooms.get(roomName)
+  if (room == null || typeof roomName !== 'string') {
+    return
+  }
+  const execMessage = data => {
+    const webrtcConns = room.webrtcConns
+    const peerId = room.peerId
+    if (data == null || data.from === peerId || (data.to !== undefined && data.to !== peerId) || room.bcConns.has(data.from)) {
+      // ignore messages that are not addressed to this conn, or from clients that are connected via broadcastchannel
+      return
+    }
+    const emitPeerChange = webrtcConns.has(data.from)
+      ? () => {}
+      : () =>
+        room.provider.emit('peers', [{
+          removed: [],
+          added: [data.from],
+          webrtcPeers: Array.from(room.webrtcConns.keys()),
+          bcPeers: Array.from(room.bcConns)
+        }])
+    switch (data.type) {
+      case 'announce':
+        if (webrtcConns.size < room.provider.maxConns) {
+          map.setIfUndefined(webrtcConns, data.from, () => new WebrtcConn(conn, true, data.from, room))
+          emitPeerChange()
+        }
+        break
+      case 'signal':
+        if (data.signal.type === 'offer') {
+          const existingConn = webrtcConns.get(data.from)
+          if (existingConn) {
+            const remoteToken = data.token
+            const localToken = existingConn.glareToken
+            if (localToken && localToken > remoteToken) {
+              log('offer rejected: ', data.from)
+              return
+            }
+            // if we don't reject the offer, we will be accepting it and answering it
+            existingConn.glareToken = undefined
+          }
+        }
+        if (data.signal.type === 'answer') {
+          log('offer answered by: ', data.from)
+          const existingConn = webrtcConns.get(data.from)
+          existingConn.glareToken = undefined
+        }
+        if (data.to === peerId) {
+          map.setIfUndefined(webrtcConns, data.from, () => new WebrtcConn(conn, false, data.from, room)).peer.signal(data.signal)
+          emitPeerChange()
+        }
+        break
+    }
+  }
+  if (room.key) {
+    if (typeof data === 'string') {
+      cryptoutils.decryptJson(buffer.fromBase64(data), room.key).then(execMessage)
+    }
+  } else {
+    execMessage(data)
+  }
+}
+
+export class SignalingConn {
   constructor (url) {
-    super(url)
+    this.url = url
     /**
      * @type {Set<WebrtcProvider>}
      */
     this.providers = new Set()
-    this.on('connect', () => {
-      log(`connected (${url})`)
+    this.setupClient()
+  }
+
+  setupClient() {
+    this.client = new ws.WebsocketClient(this.url)
+    this.client.on('connect', () => {
+      log(`connected (${this.url})`)
       const topics = Array.from(rooms.keys())
-      this.send({ type: 'subscribe', topics })
-      rooms.forEach(room =>
-        publishSignalingMessage(this, room, { type: 'announce', from: room.peerId })
-      )
+      this.client.send({ type: 'subscribe', topics })
+      this.handleConnect()
     })
-    this.on('message', m => {
+    this.client.on('message', m => {
       switch (m.type) {
         case 'publish': {
-          const roomName = m.topic
-          const room = rooms.get(roomName)
-          if (room == null || typeof roomName !== 'string') {
-            return
-          }
-          const execMessage = data => {
-            const webrtcConns = room.webrtcConns
-            const peerId = room.peerId
-            if (data == null || data.from === peerId || (data.to !== undefined && data.to !== peerId) || room.bcConns.has(data.from)) {
-              // ignore messages that are not addressed to this conn, or from clients that are connected via broadcastchannel
-              return
-            }
-            const emitPeerChange = webrtcConns.has(data.from)
-              ? () => {}
-              : () =>
-                room.provider.emit('peers', [{
-                  removed: [],
-                  added: [data.from],
-                  webrtcPeers: Array.from(room.webrtcConns.keys()),
-                  bcPeers: Array.from(room.bcConns)
-                }])
-            switch (data.type) {
-              case 'announce':
-                if (webrtcConns.size < room.provider.maxConns) {
-                  map.setIfUndefined(webrtcConns, data.from, () => new WebrtcConn(this, true, data.from, room))
-                  emitPeerChange()
-                }
-                break
-              case 'signal':
-                if (data.signal.type === 'offer') {
-                  const existingConn = webrtcConns.get(data.from)
-                  if (existingConn) {
-                    const remoteToken = data.token
-                    const localToken = existingConn.glareToken
-                    if (localToken && localToken > remoteToken) {
-                      log('offer rejected: ', data.from)
-                      return
-                    }
-                    // if we don't reject the offer, we will be accepting it and answering it
-                    existingConn.glareToken = undefined
-                  }
-                }
-                if (data.signal.type === 'answer') {
-                  log('offer answered by: ', data.from)
-                  const existingConn = webrtcConns.get(data.from)
-                  existingConn.glareToken = undefined
-                }
-                if (data.to === peerId) {
-                  map.setIfUndefined(webrtcConns, data.from, () => new WebrtcConn(this, false, data.from, room)).peer.signal(data.signal)
-                  emitPeerChange()
-                }
-                break
-            }
-          }
-          if (room.key) {
-            if (typeof m.data === 'string') {
-              cryptoutils.decryptJson(buffer.fromBase64(m.data), room.key).then(execMessage)
-            }
-          } else {
-            execMessage(m.data)
-          }
+          handleMessage(this, m.topic, m.data)
         }
       }
     })
-    this.on('disconnect', () => log(`disconnect (${url})`))
+    this.client.on('disconnect', () => log(`disconnect (${this.url})`))
+  }
+
+  handleConnect() {
+    rooms.forEach(room =>
+      publishSignalingMessage(this, room, { type: 'announce', from: room.peerId })
+    )
+  }
+
+  connected () {
+    return this.client.connected
+  }
+
+  subscribe (roomName) {
+    this.client.send({ type: 'subscribe', topics: [roomName] })
+  }
+
+  unsubscribe (roomName) {
+    this.client.send({ type: 'unsubscribe', topics: [roomName] })
+  }
+
+  publish (roomName, message) {
+    this.client.send({ type: 'publish', topic: roomName, data: message })
+  }
+
+  destroy () {
+    this.client.destroy()
   }
 }
 

--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -463,7 +463,7 @@ const openRoom = (doc, provider, name, key) => {
  * @param {Room} room
  * @param {any} data
  */
-const publishSignalingMessage = (conn, room, data) => {
+export const publishSignalingMessage = (conn, room, data) => {
   if (room.key) {
     cryptoutils.encryptJson(data, room.key).then(data => {
       conn.publish(room.name, buffer.toBase64(data))

--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -463,7 +463,7 @@ const openRoom = (doc, provider, name, key) => {
  * @param {Room} room
  * @param {any} data
  */
-export const publishSignalingMessage = (conn, room, data) => {
+const publishSignalingMessage = (conn, room, data) => {
   if (room.key) {
     cryptoutils.encryptJson(data, room.key).then(data => {
       conn.publish(room.name, buffer.toBase64(data))

--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -484,21 +484,19 @@ export class SignalingConn {
   }
 
   setupClient() {
-    // if (this.client === undefined) {
-      this.client = new ws.WebsocketClient(this.url)
-      this.client.on('connect', () => {
-        log(`connected (${this.url})`)
-        this.handleConnect()
-      })
-      this.client.on('message', m => {
-        switch (m.type) {
-          case 'publish': {
-            this.handleMessage(m.topic, m.data)
-          }
+    this.client = new ws.WebsocketClient(this.url)
+    this.client.on('connect', () => {
+      log(`connected (${this.url})`)
+      this.handleConnect()
+    })
+    this.client.on('message', m => {
+      switch (m.type) {
+        case 'publish': {
+          this.handleMessage(m.topic, m.data)
         }
-      })
-      this.client.on('disconnect', () => log(`disconnect (${this.url})`))
-    // }
+      }
+    })
+    this.client.on('disconnect', () => log(`disconnect (${this.url})`))
   }
 
   handleConnect() {

--- a/src/y-webrtc.js
+++ b/src/y-webrtc.js
@@ -484,11 +484,10 @@ export class SignalingConn {
   }
 
   setupClient() {
-    if (this.client === undefined) {
+    // if (this.client === undefined) {
       this.client = new ws.WebsocketClient(this.url)
       this.client.on('connect', () => {
         log(`connected (${this.url})`)
-        this.joinAllRooms()
         this.handleConnect()
       })
       this.client.on('message', m => {
@@ -499,10 +498,14 @@ export class SignalingConn {
         }
       })
       this.client.on('disconnect', () => log(`disconnect (${this.url})`))
-    }
+    // }
   }
 
   handleConnect() {
+    const topics = Array.from(rooms.keys())
+    topics.forEach(topic =>
+      this.subscribe(topic)
+    )
     rooms.forEach(room =>
       publishSignalingMessage(this, room, { type: 'announce', from: room.peerId })
     )
@@ -589,13 +592,6 @@ export class SignalingConn {
 
   destroy () {
     this.client.destroy()
-  }
-
-  joinAllRooms() {
-    const topics = Array.from(rooms.keys())
-    topics.forEach(topic =>
-      this.subscribe(topic)
-    )
   }
 }
 


### PR DESCRIPTION
**This is a draft of a PR that will ultimately be submitted upstream to `yjs/y-webrtc`**

Refactors SignalingConn and related code to allow swapping out the signaling server client by extending WebrtcProvider and SignalingConn.

* Creates `subscribe`, `unsubscribe`, and `publish` methods for `SignalingConn` so external code doesn't need to know how to format signaling server messages.
* Exports `publishSignalingMessage` so classes derived from `SignalingConn` can make use of it, as well as other parts of y-webrtc.
    * Would it be better to move this logic into the `publish` method and refactor other y-webrtc code that calls it?
* Creates a `connected` method, since clients may determine signaling server connectivity differently.
* Moves websocket client initialization into a `setupClient` method which can be overridden to use a different signaling server client (ex: Azure Web PubSub client) including differing message event names (ex: `message` vs `group-message`)
* Moves the `rooms` iteration into a `handleConnect` method, so that global set does not have to be exported and used in derived classes.
* Creates a `handleMessage` method so the logic can be reused and does not need to be included in the client `message` event definitions of derived classes.

**Question**

Overriding `WebrtcProvider` just to change the class used for signaling connections seems excessive. Is there a way we can pass this into the base WebrtcProvider instead?

This is the only line we need to change in the `connect()` method:
`const signalingConn = map.setIfUndefined(signalingConns, url, () => new SignalingConn(url))`